### PR TITLE
Fix: Configure HttpClient for Blazor client

### DIFF
--- a/PoHappyTrump.Client/Program.cs
+++ b/PoHappyTrump.Client/Program.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using System.Net.Http;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
The button on the home page was not working because the HttpClient in the PoHappyTrump.Client project was not configured with a base address. This prevented it from making API calls to the backend.

This commit adds the necessary HttpClient configuration in PoHappyTrump.Client/Program.cs, allowing the GetMessage method in Home.razor to successfully call the TrumpMessage API endpoint.